### PR TITLE
Add support for other buzz devices

### DIFF
--- a/src/connectDevice.ts
+++ b/src/connectDevice.ts
@@ -15,9 +15,13 @@ export type ConnectDeviceType = (nodeHidLib: any) => nodeHid.HID;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function (nodeHidLib: any): nodeHid.HID {
-  try {
-    return new nodeHidLib.HID(hardware.VENDOR_ID, hardware.PRODUCT_ID);
-  } catch (err) {
-    return findDeviceByName(nodeHidLib);
+  const device = nodeHid.devices().filter(
+    (d) => d.vendorId === hardware.VENDOR_ID && hardware.PRODUCT_IDS.includes(d.productId)
+  )[0];
+
+  if (device) {
+    return new nodeHidLib.HID(device.vendorId, device.productId);
   }
+
+  return findDeviceByName(nodeHidLib);
 }

--- a/src/connectDevice.ts
+++ b/src/connectDevice.ts
@@ -7,6 +7,11 @@ function findDeviceByName(nodeHidLib: any) {
   const buzzDevice = nodeHidLib
     .devices()
     .find((d: nodeHid.Device) => d?.product?.match(/Buzz/));
+
+  if (!buzzDevice) {
+    throw new Error("No device found! Please connect a device first.");
+  }
+
   return new nodeHidLib.HID(buzzDevice.vendorId, buzzDevice.productId);
 }
 

--- a/src/hardware.ts
+++ b/src/hardware.ts
@@ -1,4 +1,4 @@
 export default {
   VENDOR_ID: 1356,
-  PRODUCT_ID: 4096,
+  PRODUCT_IDS: [2, 4096],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ module.exports = (singleMode = true): IBuzzer | IBuzzer[] => {
   const buzzers: IBuzzer[] = [];
   const devices = nodeHid.devices();
   const buzzDongles = devices.filter(
-    (d) => d.vendorId === hw.VENDOR_ID && d.productId === hw.PRODUCT_ID
+    (d) => d.vendorId === hw.VENDOR_ID && hw.PRODUCT_IDS.includes(d.productId)
   );
   buzzDongles.forEach((bd) => {
     if (typeof bd?.path === "string") {


### PR DESCRIPTION
This PR adds support for devices with different product IDs.

Some devices appear to have a different product ID. This was also discovered in an [issue](https://github.com/functino/buzz-buzzers/issues/8) in the original repo.
These devices have the same vendor ID but a different product ID of `0002`. The devices also need to be configured manually on Windows 10.


In another buzzer [repo](https://github.com/gueggel/SJ.Buzzer), this workaround was discovered (translated):

>## Driver settings for the Playstation buzzer
>
>If you connect the Buzzer to the PC, Windows also detects a device and tries to install a driver. The installation fails because there is no driver. Unfortunately, Windows 10 now classifies the Buzzer as a non-functioning USB hub. But with this setting it is not possible to query the buzzers. The buzzers have to be configured to be recognized as HID (Human Interface Device).
>
>The following steps are necessary:
>
>Open the device manager.
>Click with the right mouse button on the standard USB HUB and select "Update driver..." in the context menu.
>Start the item "Search for driver software on the computer".
>Start the item "Select from a list of device drivers on the computer".
>Select the USB input device entry from the list.
>Finish the installation by clicking the Next button.
>If everything worked, you will find the Buzzer as a game controller in Windows.